### PR TITLE
Fix severe perf degradation reading Stored file in Mono

### DIFF
--- a/src/Zip/ZipFile.cs
+++ b/src/Zip/ZipFile.cs
@@ -3778,8 +3778,11 @@ namespace ICSharpCode.SharpZipLib.Zip
 							return 0;
 						}
 					}
-					
-					baseStream_.Seek(readPos_, SeekOrigin.Begin);
+					// Protect against Stream implementations that throw away their buffer on every Seek
+					// (for example, Mono FileStream)
+					if (baseStream_.Position != readPos_) {
+						baseStream_.Seek(readPos_, SeekOrigin.Begin);
+					}
 					int readCount = baseStream_.Read(buffer, offset, count);
 					if (readCount > 0) {
 						readPos_ += readCount;


### PR DESCRIPTION
Reference icsharpcode/SharpZipLib/pull/85

When reading a stored file, ZipFile returns a PartialInputStream
directly instead of wrapping it with a decompression layer.

PartialInputStream handles sharing the underlying stream among
multiple threads by calling Seek() before each read.

Unlike Microsoft's reference implementation, Mono's FileStream
flushes its internal read buffer on every Seek.
