### PR TITLE
Fix AES encrypted input stream throws exception on close

### DIFF
--- a/src/Encryption/ZipAESStream.cs
+++ b/src/Encryption/ZipAESStream.cs
@@ -129,11 +129,10 @@ namespace ICSharpCode.SharpZipLib.Encryption {
 					if (byteCount > AUTH_CODE_LENGTH) {
 						// At least one byte of data plus auth code
 						int finalBlock = byteCount - AUTH_CODE_LENGTH;
-						_transform.TransformBlock(_slideBuffer,
-												  _slideBufStartPos,
-												  finalBlock,
-												  outBuffer,
-												  offset);
+						byte[] fb = _transform.TransformFinalBlock(_slideBuffer,
+															  _slideBufStartPos,
+															  finalBlock);
+						Array.Copy(fb, 0, outBuffer, offset, fb.Length);
 
 						nBytes += finalBlock;
 						_slideBufStartPos += finalBlock;

--- a/src/Encryption/ZipAESTransform.cs
+++ b/src/Encryption/ZipAESTransform.cs
@@ -162,11 +162,20 @@ namespace ICSharpCode.SharpZipLib.Encryption {
 		#region ICryptoTransform Members
 
 		/// <summary>
-		/// Not implemented.
+		/// Implement the ICryptoTransform method.
 		/// </summary>
 		public byte[] TransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount) {
-
-			throw new NotImplementedException("ZipAESTransform.TransformFinalBlock");
+			byte[] result;
+			if (!_finalised)
+			{
+				result = new byte[inputCount];
+				TransformBlock(inputBuffer, inputOffset, inputCount, result, 0);
+			}
+			else
+			{
+				result = new byte[0];
+			}
+			return result;
 		}
 
 		/// <summary>


### PR DESCRIPTION
Added SlavaMov's AES TransformFinalBlock implementation from
http://community.sharpdevelop.net/forums/p/18021/46959.aspx
