### PR TITLE
Bugfix/unicode Unicode File/Directory Support

### DIFF
--- a/src/Zip/ZipEntryFactory.cs
+++ b/src/Zip/ZipEntryFactory.cs
@@ -42,6 +42,7 @@ using System;
 using System.IO;
 
 using ICSharpCode.SharpZipLib.Core;
+using System.Text;
 
 namespace ICSharpCode.SharpZipLib.Zip
 {
@@ -235,7 +236,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 			ZipEntry result = new ZipEntry(nameTransform_.TransformFile(entryName != null && entryName.Length > 0 ? entryName : fileName));
 			result.IsUnicodeText = isUnicodeText_;
 
-			int externalAttributes = 0;
+            int externalAttributes = 0;
 			bool useAttributes = (setAttributes_ != 0);
 
 			FileInfo fi = null;

--- a/src/Zip/ZipEntryFactory.cs
+++ b/src/Zip/ZipEntryFactory.cs
@@ -236,6 +236,15 @@ namespace ICSharpCode.SharpZipLib.Zip
 			ZipEntry result = new ZipEntry(nameTransform_.TransformFile(entryName != null && entryName.Length > 0 ? entryName : fileName));
 			result.IsUnicodeText = isUnicodeText_;
 
+            Encoding defaultEncoding = Encoding.GetEncoding(ZipConstants.DefaultCodePage);
+            byte[] unicodeFileNameBytes = defaultEncoding.GetBytes(result.Name);
+            string unicodeFileName = defaultEncoding.GetString(unicodeFileNameBytes);
+            if (unicodeFileName != result.Name)
+            {
+                result.IsUnicodeText = true;
+            }
+
+
             int externalAttributes = 0;
 			bool useAttributes = (setAttributes_ != 0);
 

--- a/src/Zip/ZipEntryFactory.cs
+++ b/src/Zip/ZipEntryFactory.cs
@@ -200,16 +200,33 @@ namespace ICSharpCode.SharpZipLib.Zip
 			set { isUnicodeText_ = value; }
 		}
 
-		#endregion
+        #endregion
 
-		#region IEntryFactory Members
+        #region Private Methods
 
-		/// <summary>
-		/// Make a new <see cref="ZipEntry"/> for a file.
-		/// </summary>
-		/// <param name="fileName">The name of the file to create a new entry for.</param>
-		/// <returns>Returns a new <see cref="ZipEntry"/> based on the <paramref name="fileName"/>.</returns>
-		public ZipEntry MakeFileEntry(string fileName)
+        /// <summary>
+        /// Check whether the file name is unicode encoded or not.
+        /// </summary>
+        /// <param name="fileName">The name of the file to check its encoding.</param>
+        /// <returns></returns>
+        private bool IsUnicodeFileName(string fileName)
+        {
+            Encoding defaultEncoding = Encoding.GetEncoding(ZipConstants.DefaultCodePage);
+            byte[] unicodeFileNameBytes = defaultEncoding.GetBytes(fileName);
+            string unicodeFileName = defaultEncoding.GetString(unicodeFileNameBytes);
+            return unicodeFileName != fileName;
+        }
+
+        #endregion
+
+        #region IEntryFactory Members
+
+        /// <summary>
+        /// Make a new <see cref="ZipEntry"/> for a file.
+        /// </summary>
+        /// <param name="fileName">The name of the file to create a new entry for.</param>
+        /// <returns>Returns a new <see cref="ZipEntry"/> based on the <paramref name="fileName"/>.</returns>
+        public ZipEntry MakeFileEntry(string fileName)
 		{
 			return MakeFileEntry(fileName, null, true);
 		}
@@ -236,14 +253,10 @@ namespace ICSharpCode.SharpZipLib.Zip
 			ZipEntry result = new ZipEntry(nameTransform_.TransformFile(entryName != null && entryName.Length > 0 ? entryName : fileName));
 			result.IsUnicodeText = isUnicodeText_;
 
-            Encoding defaultEncoding = Encoding.GetEncoding(ZipConstants.DefaultCodePage);
-            byte[] unicodeFileNameBytes = defaultEncoding.GetBytes(result.Name);
-            string unicodeFileName = defaultEncoding.GetString(unicodeFileNameBytes);
-            if (unicodeFileName != result.Name)
+            if (IsUnicodeFileName(result.Name))
             {
                 result.IsUnicodeText = true;
             }
-
 
             int externalAttributes = 0;
 			bool useAttributes = (setAttributes_ != 0);


### PR DESCRIPTION
Reference icsharpcode/SharpZipLib/pull/96

Bugfix for Unicode support of file and directory names.
Previously created corrupted file/directory names, that underscore character ('') took place instead of each unicode character in the file/directory name. e.g.: ____.js
