### PR TITLE
the stream is not seek-able, access to Length should return exception

### DIFF
--- a/src/Zip/Compression/Streams/InflaterInputStream.cs
+++ b/src/Zip/Compression/Streams/InflaterInputStream.cs
@@ -549,7 +549,8 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 		/// </summary>
 		public override long Length {
 			get {
-				return inputBuffer.RawLength;
+				//return inputBuffer.RawLength;
+                throw new NotSupportedException("InflaterInputStream Length is not supported");
 			}
 		}
 		


### PR DESCRIPTION
Reference icsharpcode/SharpZipLib/issues/80 and icsharpcode/SharpZipLib/pull/84

just simply throw exception is enough, to get the real stream size before reading, should use entry.size.
